### PR TITLE
remove `yarn global install` which doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ If you are not familiar with the command line, please see this [Codedemy article
 
 ### 2. Install Bluprntr
 
-Run `yarn global install` from the folder where the Bluprntr project was cloned/extracted.
-
 ```bash
 # Set the current directory to the bluprntr folder.
 cd ./bluprntr


### PR DESCRIPTION
Thanks for a great tool!

Confusingly enough, there's no such thing as `yarn global install`. The block with commands provides all the necessary information so no need for the extra line, I think!